### PR TITLE
Add kernel nonconformity score paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ School (CEIBS), 2026)
 589. [Full Conformal Adaptation of Medical Vision-Language Models](https://link.springer.com/chapter/10.1007/978-3-031-96625-5_19) (2025) VLM MEDICAL 🔥🔥🔥🔥🔥
 590. [Conditional Conformal Risk Adaptation](https://arxiv.org/abs/2504.07611) (2025) RISK CONTROL SEGMENTATION 🔥🔥🔥🔥🔥
 591. [A conformalized learning of a prediction set with applications to medical imaging classification](https://arxiv.org/abs/2408.05037) (2024) MEDICAL IMAGING 🔥🔥🔥🔥🔥
+592. - [A Kernel Nonconformity Score for Multivariate Conformal Prediction](https://arxiv.org/abs/2604.21595) by Louis Meyer, Wenkai Xu (University of Warwick, 2026).
 
 ## Conformal Prediction for Time Series Forecasting
 1. [Conformal prediction interval for dynamic time-series](https://proceedings.mlr.press/v139/xu21h.html) by Chen Xu, Yao Xie (Georgia Tech, 2021) TIME SERIES 🚀🚀🚀🚀🚀 🔥🔥🔥🔥🔥 [Python Code](https://github.com/hamrel-cxu/EnbPI) [Video](https://vimeo.com/583595474) [Video ICML2021](https://papertalk.org/papertalks/32044)
@@ -1340,4 +1341,3 @@ for probabilistic wind-speed forecasting](https://lup.lub.lu.se/luur/download?fu
 6. [How to correctly, yet efficiently model the uncertainty on predictions](https://threadreaderapp.com/thread/1584905067718647808.html) by Nico Wolf (2022)
 7. [Top 10 Github libraries for Conformal Prediction](https://threadreaderapp.com/thread/1609112769017552897.html) by Valeriy Manokhin (2022)
 8. [Robots That Ask For Help](https://threadreaderapp.com/thread/1677000811803443213.html) by Allen Z. Ren (2023) 🍾🍾🍾🍾🍾🔥🔥🔥🔥🔥
-

--- a/README.md
+++ b/README.md
@@ -1146,7 +1146,7 @@ School (CEIBS), 2026)
 589. [Full Conformal Adaptation of Medical Vision-Language Models](https://link.springer.com/chapter/10.1007/978-3-031-96625-5_19) (2025) VLM MEDICAL 🔥🔥🔥🔥🔥
 590. [Conditional Conformal Risk Adaptation](https://arxiv.org/abs/2504.07611) (2025) RISK CONTROL SEGMENTATION 🔥🔥🔥🔥🔥
 591. [A conformalized learning of a prediction set with applications to medical imaging classification](https://arxiv.org/abs/2408.05037) (2024) MEDICAL IMAGING 🔥🔥🔥🔥🔥
-592. - [A Kernel Nonconformity Score for Multivariate Conformal Prediction](https://arxiv.org/abs/2604.21595) by Louis Meyer, Wenkai Xu (University of Warwick, 2026).
+592. - [A Kernel Nonconformity Score for Multivariate Conformal Prediction](https://arxiv.org/abs/2604.21595) by Louis Meyer, Wenkai Xu (University of Warwick, 2026) [Code](https://github.com/meyerlouis/mvcp)
 
 ## Conformal Prediction for Time Series Forecasting
 1. [Conformal prediction interval for dynamic time-series](https://proceedings.mlr.press/v139/xu21h.html) by Chen Xu, Yao Xie (Georgia Tech, 2021) TIME SERIES 🚀🚀🚀🚀🚀 🔥🔥🔥🔥🔥 [Python Code](https://github.com/hamrel-cxu/EnbPI) [Video](https://vimeo.com/583595474) [Video ICML2021](https://papertalk.org/papertalks/32044)


### PR DESCRIPTION
Added "A Kernel Nonconformity Score for Multivariate Conformal Prediction" (Meyer & Xu, 2026) to the multivariate/regression section. The paper introduces a kernel-based nonconformity score for multivariate conformal prediction with coverage guarantees.

https://arxiv.org/abs/2604.21595


