### PR TITLE
Add bayes-hdc — conformal classification, regression & anomaly detection in JAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Leo Dreyfus-Schmidt (Dataiku, 2020). 🔥🔥🔥🔥🔥
 5. [Puncc (Predictive uncertainty calibration and conformalization)](https://github.com/deel-ai/puncc) [paper](https://proceedings.mlr.press/v204/mendil23a/mendil23a.pdf) [slides](https://copa-conference.com/presentations/COPA_2023_mouhcine_mendil_puncc.pdf) 🔥🔥🔥🔥🔥
 6. [ConformaSight Global Explainer Package 📦](https://github.com/rabia174/ConformaSight) by Fatıma Rabia Yapıcıoğlu (2025)
 7. [unquad - Conformal Anomaly Detection](https://github.com/OliverHennhoefer/unquad) 🔥🔥🔥🔥🔥
+8. [bayes-hdc - Conformal prediction and anomaly detection on hyperdimensional computing, in JAX](https://github.com/rlogger/bayes-hdc) by Rajdeep Singh (2026)
 8. [Puncc (Predictive uncertainty calibration and conformalization)](https://github.com/deel-ai/puncc) [paper](https://proceedings.mlr.press/v204/mendil23a/mendil23a.pdf) [slides](https://copa-conference.com/presentations/COPA_2023_mouhcine_mendil_puncc.pdf) 🔥🔥🔥🔥🔥
 9. [Nixtla mlforecast](https://nixtlaverse.nixtla.io/mlforecast/) TIME SERIES 🚀🚀🚀🚀🚀 🔥🔥🔥🔥🔥
 10.   [Nixtla statsforecast](https://nixtla.github.io/statsforecast/docs/tutorials/conformalprediction.html#introduction) TIME SERIES 🚀🚀🚀🚀🚀 🔥🔥🔥🔥🔥


### PR DESCRIPTION
bayes-hdc ships split-conformal prediction across three modes — APS classifier (Romano et al. 2020), absolute-residual regressor (Lei et al. 2018), and a one-class anomaly detector with conformal p-values (Laxhammar 2014; Bates et al. 2023, including Benjamini-Hochberg FDR control across batches) — on hyperdimensional-computing encoders, in JAX.

Distinct from the other entries in that the conformal layer wraps an HDC/VSA backbone and composes with `jax.jit`/`vmap`/`grad`. The coverage and FDR guarantees are tested directly in the suite (666 tests), benchmarks are committed with provenance, and there's a 2-minute Colab quickstart.

- Repo: https://github.com/rlogger/bayes-hdc
- PyPI: `pip install bayes-hdc`
- DOI: https://doi.org/10.5281/zenodo.20635099

One line added to the Python libraries section, next to the other conformal-anomaly-detection entry. Thanks for maintaining the list!