### PR TITLE
Add CERT-FLOW: conformal-certified route planning library (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ Leo Dreyfus-Schmidt (Dataiku, 2020). 🔥🔥🔥🔥🔥
 29. [HyperConformal: Conformal Prediction for Hyperdimensional Computing](https://github.com/danieleschmidt/HyperConformal)  🔥🔥🔥🔥🔥 (2025)
 30. [(F)FCP : Predictive Inference with (Fast) Feature Conformal Prediction](https://github.com/ElvisWang1111/F-F-CP) 🔥🔥🔥🔥🔥 (2026)
 
+31. [CERT-FLOW](https://github.com/Archerkattri/CERT-FLOW) - Certified route planning under drifting costs: age-weighted non-exchangeable conformal certificates (LB ≤ OPT ≤ UB) on the optimal route, certificate-directed sensing, and proof-gated preprocessing; 223 tests, 16 reproduction pipelines. *Krishi Attri / 2026.* 🔥🔥🔥🔥🔥
+
 ## Conformal Prediction Libraries in R
 1. [pintervals - Model agnostic prediction intervals](https://github.com/Doktorandahl/pintervals) [paper](https://arxiv.org/abs/2601.03994) by David Randahl, Anders Hjort, Jonathan P. Williams (2026) 🔥🔥🔥🔥🔥 
 2.  [Conformal Prediction ih tidymodels](https://github.com/tidymodels/tidymodels.org/pull/23) by Max Kuhn (Posit/RStudio, 2023) [video](https://www.youtube.com/watch?v=3omi4lm1da0) 🔥🔥🔥🔥🔥


### PR DESCRIPTION
## What

Adds [CERT-FLOW](https://github.com/Archerkattri/CERT-FLOW) to the **Conformal Prediction Libraries in Python** section as entry 31.

## Why it fits

CERT-FLOW applies **age-weighted non-exchangeable conformal prediction** (Barber et al. 2023 style) to route planning under drifting edge costs. Every replanning round it emits a high-probability certificate `LB ≤ OPT ≤ UB` on the optimal route cost, then spends a sensing budget where it shrinks the certified gap fastest. It also ships certified Contraction Hierarchies for large road networks.

- MIT-licensed, `pip install certflow`
- 223 tests, 16 reproduction pipelines (METR-LA, PEMS-BAY traffic replay)
- Measured coverage at or above the claimed level on every reported condition
- Disclosure: I am the author (Krishi Attri)